### PR TITLE
Ported AppSchemaValidator to JAXP to remove Xerces dependency

### DIFF
--- a/modules/extension/app-schema/app-schema-resolver/pom.xml
+++ b/modules/extension/app-schema/app-schema-resolver/pom.xml
@@ -45,21 +45,6 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>xerces</groupId>
-            <artifactId>xercesImpl</artifactId>
-            <version>2.7.1</version>
-        </dependency>
-        <dependency>
-            <groupId>xml-apis</groupId>
-            <artifactId>xml-apis-xerces</artifactId>
-            <version>2.7.1</version>
-        </dependency>
-        <dependency>
-            <groupId>xml-apis</groupId>
-            <artifactId>xml-apis</artifactId>
-            <version>1.3.04</version>
-        </dependency>
-        <dependency>
             <groupId>org.apache.xml</groupId>
             <artifactId>xml-commons-resolver</artifactId>
             <version>1.2</version>

--- a/modules/extension/app-schema/app-schema-resolver/src/main/java/org/geotools/xml/AppSchemaValidator.java
+++ b/modules/extension/app-schema/app-schema-resolver/src/main/java/org/geotools/xml/AppSchemaValidator.java
@@ -27,16 +27,15 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.apache.xerces.parsers.SAXParser;
-import org.apache.xerces.xni.XMLResourceIdentifier;
-import org.apache.xerces.xni.XNIException;
-import org.apache.xerces.xni.parser.XMLEntityResolver;
-import org.apache.xerces.xni.parser.XMLInputSource;
+import javax.xml.parsers.SAXParser;
+import javax.xml.parsers.SAXParserFactory;
+
 import org.xml.sax.ErrorHandler;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 import org.xml.sax.SAXParseException;
 import org.xml.sax.XMLReader;
+import org.xml.sax.ext.EntityResolver2;
 
 /**
  * A class to perform XML schema validation against schemas found using an {@link AppSchemaResolver}
@@ -125,35 +124,6 @@ public class AppSchemaValidator {
     }
 
     /**
-     * Configure the parser.
-     * 
-     * @param parser
-     *            the XML parser to configure
-     */
-    private void configure(XMLReader parser) {
-        try {
-            // See: http://xerces.apache.org/xerces2-j/features.html
-            // (1) Enable validation in the parser.
-            parser.setFeature("http://xml.org/sax/features/validation", true);
-            // (2) Specify that validation is against XML schemas.
-            parser.setFeature("http://apache.org/xml/features/validation/schema", true);
-            // (2a) Enable the most pedantic level of checking of the schemas themselves.
-            // This has no effect on checking of instance documents, so we leave it turned off.
-            // It is left here for the education of the reader.
-            // parser.setFeature("http://apache.org/xml/features/validation/schema-full-checking",
-            // true);
-            // (3) Set the entity resolver, which is used to look up XML schemas.
-            // See: http://xerces.apache.org/xerces2-j/faq-xcatalogs.html
-            parser.setProperty("http://apache.org/xml/properties/internal/entity-resolver",
-                    new AppSchemaXMLEntityResolver());
-        } catch (Exception e) {
-            // Validation failures do not throw. This block is entered if there is, for example, an
-            // I/O error occurs or a schema cannot be located during parsing.
-            throw new RuntimeException(e);
-        }
-    }
-
-    /**
      * Parse an XML instance document read from an {@link InputStream}, recording any validation
      * failures failures.
      * 
@@ -161,16 +131,28 @@ public class AppSchemaValidator {
      *            stream from which XML instance document is read
      */
     public void parse(InputStream input) {
-        XMLReader parser = new SAXParser();
-        configure(parser);
+        SAXParserFactory parserFactory = SAXParserFactory.newInstance();
+        parserFactory.setNamespaceAware(true);
+        parserFactory.setValidating(true);
+        XMLReader xmlReader;
+        try {
+            SAXParser parser = parserFactory.newSAXParser();
+            // Validation is against XML Schema
+            parser.setProperty("http://java.sun.com/xml/jaxp/properties/schemaLanguage",
+                    "http://www.w3.org/2001/XMLSchema");
+            xmlReader = parser.getXMLReader();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        xmlReader.setEntityResolver(new AppSchemaEntityResolver());
         // We principally care about the failures themselves, but it is also possible to install a
         // ContentHandler to output annotated XML that identifies the precise location of failures.
         // That can be done with a serializer that implements both ContentHandler and ErrorHandler.
         // It should be installed here (and used for the error handler):
         // parser.setContentHandler(contentHandler);
-        parser.setErrorHandler(new AppSchemaValidatorErrorHandler());
+        xmlReader.setErrorHandler(new AppSchemaValidatorErrorHandler());
         try {
-            parser.parse(new InputSource(input));
+            xmlReader.parse(new InputSource(input));
         } catch (RuntimeException e) {
             // Avoid gratuitous exception chaining.
             // Resolver failures pass through this block.
@@ -350,28 +332,46 @@ public class AppSchemaValidator {
     }
 
     /**
-     * An {@link XMLEntityResolver} that uses the enclosing instance's {@link AppSchemaResolver} to
-     * look up XML entities (that is, XML schemas).
-     * 
+     * An {@link EntityResolver2} that uses the enclosing instance's {@link AppSchemaResolver} to look up XML entities (that is, XML schemas).
      */
-    private class AppSchemaXMLEntityResolver implements XMLEntityResolver {
+    private class AppSchemaEntityResolver implements EntityResolver2 {
 
         /**
-         * @see org.apache.xerces.xni.parser.XMLEntityResolver#resolveEntity(org.apache.xerces.xni.XMLResourceIdentifier)
+         * Always throws {@link UnsupportedOperationException}. The {@link EntityResolver2} interface must be used so that relative URLs are resolved
+         * correctly. If this method is called, it means that the parser is probably misconfigured.
+         * 
+         * @see org.xml.sax.EntityResolver#resolveEntity(java.lang.String, java.lang.String)
          */
-        public XMLInputSource resolveEntity(XMLResourceIdentifier resourceIdentifier)
-                throws XNIException, IOException {
-            if (resourceIdentifier.getLiteralSystemId() == null) {
-                throw new RuntimeException("Schema validation failure caused by "
-                        + "missing schemaLocation for namespace "
-                        + resourceIdentifier.getNamespace());
-            } else {
-                // We use AppSchemaResolver.resolve(String, String) to ensure relative
-                // imports work across jar file boundaries.
-                return new XMLInputSource(resourceIdentifier.getPublicId(), resolver.resolve(
-                        resourceIdentifier.getLiteralSystemId(),
-                        resourceIdentifier.getBaseSystemId()), resourceIdentifier.getBaseSystemId());
-            }
+        @Override
+        public InputSource resolveEntity(String publicId, String systemId) throws SAXException,
+                IOException {
+            throw new UnsupportedOperationException(
+                    "Misconfigured parser: EntityResolver2 interface must be used "
+                            + "so that relative URLs are resolved correctly");
+        };
+
+        /**
+         * Always returns null to indicate that there is no external subset.
+         * 
+         * @see org.xml.sax.ext.EntityResolver2#getExternalSubset(java.lang.String, java.lang.String)
+         */
+        @Override
+        public InputSource getExternalSubset(String name, String baseURI) {
+            return null;
+        }
+
+        /**
+         * Return an {@link InputSource} for the resolved schema location. Note that the {@link EntityResolver2} interface must be used because
+         * baseURI is needed to resolve relative URIs. The resolver uses baseURI to find the original unresolved context (which it has stored); this
+         * is then used to construct the unresolved URI of the schema. In the case of downloaded schemas, the original URI is used to download the
+         * schema into the cache; the resolved URI is the location of the cached schema.
+         * 
+         * @see org.xml.sax.ext.EntityResolver2#resolveEntity(java.lang.String, java.lang.String, java.lang.String, java.lang.String)
+         */
+        @Override
+        public InputSource resolveEntity(String name, String publicId, String baseURI,
+                String systemId) throws SAXException, IOException {
+            return new InputSource(resolver.resolve(systemId, baseURI));
         }
 
     }

--- a/modules/extension/app-schema/app-schema-resolver/src/test/java/org/geotools/xml/AppSchemaValidatorTest.java
+++ b/modules/extension/app-schema/app-schema-resolver/src/test/java/org/geotools/xml/AppSchemaValidatorTest.java
@@ -167,20 +167,4 @@ public class AppSchemaValidatorTest {
                 + "\"><wfs:Query typeName=\"test\"/></wfs:GetFeature>", null);
     }
 
-    /**
-     * Test that a GetFeature with a missing schemaLocation causes a sensible error message.
-     */
-    @Test
-    public void validateGetFeatureWithMissingSchemaLocation() {
-        try {
-            AppSchemaValidator.validate("<wfs:GetFeature " //
-                    + "xmlns:wfs=\"http://www.opengis.net/wfs\">" //
-                    + "<wfs:Query typeName=\"test\"/></wfs:GetFeature>", null);
-            Assert.fail("Unexpected validation success for GetFeature with missing schemaLocation");
-        } catch (Exception e) {
-            Assert.assertEquals(e.getMessage(), "Schema validation failure caused by "
-                    + "missing schemaLocation for namespace http://www.opengis.net/wfs");
-        }
-    }
-
 }


### PR DESCRIPTION
Justin,

this change ports AppSchemaValidator to JAXP to remove the explicit Xerces dependency. Note that xmlcodegen still fails to build (I commented it out for testing).

With noxmldeps GeoTools, there is a unit test failure in GeoServer (app-schema-test SecondaryNamespaceExceptionTest). Looks like a side effect of your dexercesification is that undefined namespace prefixes (null:) are now passed through the GML32OutputFormat XSLT rather that causing an ows:ExceptionReport. Not sure why. Also need to remove the xerces dependencies in the release module.

Kind regards,
Ben.
